### PR TITLE
user should not redirect to homepage if he navigated to different page

### DIFF
--- a/app/assets/javascripts/navigation_helpers.coffee
+++ b/app/assets/javascripts/navigation_helpers.coffee
@@ -1,2 +1,2 @@
-window.redirect_to = (url, delay) ->
-  window.setTimeout ( -> window.location.href = url ), delay
+window.redirect_to = (url, originalLocation, delay) ->
+  window.setTimeout ( -> window.location.href = url if originalLocation == window.location.href ), delay

--- a/app/views/sessions/logout_success.html.erb
+++ b/app/views/sessions/logout_success.html.erb
@@ -6,6 +6,6 @@
 
 <script>
     $(function () {
-        redirect_to('<%= root_path %>', 5000);
+        redirect_to('<%= root_path %>', window.location.href, 5000);
     });
 </script>


### PR DESCRIPTION
Currently, if he logs out and then navigated to a different page (within the 5-second delay), he is still redirected to home page. 

We should not redirect the user he is manually going to a different page. So the quick fix is to redirect the user only if he's still in the logout success page after the 5-second delay. 
