### PR TITLE
Add configuration to use the *.scopeabout.com certificate

### DIFF
--- a/.ebextensions/securelistener-clb.config
+++ b/.ebextensions/securelistener-clb.config
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elb:listener:443:
+    SSLCertificateId: arn:aws:acm:eu-west-1:918660201461:certificate/c7835d07-d99e-4ac9-b424-2c0154aa1541
+    ListenerProtocol: HTTPS
+    InstancePort: 80


### PR DESCRIPTION
### Description

The loadbalancer uses HTTPS for outside world. When the user hit prod.scopeabout.com. The request hits the load balancer. Then it send the request to the app instance via HTTP. It is ok to have HTTP for this as it is internal.

If you use the AWS URL, it does not get verified but you can still use the app via HTTPS.

### Dev Notes

Add configuration to use the *.scopeabout.com certificate  for new test environments. https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html