### PR TITLE
Remove top level user management routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,5 @@
 Rails.application.routes.draw do
-  get 'settings/index', to: 'settings#index'
-  get 'settings/update_password', to: 'settings#edit_password'
-  patch 'settings/update_password', to: 'settings#update_password'
-  get 'settings/update_profile_photo', to: 'settings#edit_profile_photo'
-  patch 'settings/update_profile_photo', to: 'settings#update_profile_photo'
-
-  get 'profile/edit_basic',   to: 'profile#edit_basic'
-  patch 'profile/edit_basic', to: 'profile#update_basic'
-
-  get 'profile', to: 'profile#show'
-
   get '/push_notifications', to: 'welcome_page#push_notifications'
   get '/cookies', to: 'welcome_page#cookies_consent'
-  get 'sessions/new'
-  get 'sessions/logout_success'
-  get '/welcome', to: 'welcome_page#welcome'
-  get    '/login',   to: 'sessions#new'
-  post   '/login',   to: 'sessions#create'
-  get 'logout', to: 'sessions#destroy', as: 'logout'
-  get 'register', to: 'users#new'
-  resources 'users'
   root 'welcome_page#welcome'
 end


### PR DESCRIPTION
This will stop users from creating accounts, and managing their profiles. This is because most of them should happen under the relevant organization that they access to.